### PR TITLE
UI/chat input box

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import TownsServiceClient, { TownJoinResponse } from './classes/TownsServiceClie
 import Video from './classes/Video/Video';
 import SpatialChat from './components/spatialChat';
 import store from './redux/store';
+import Constants from './constants';
 
 type CoveyAppUpdate =
   | { action: 'doConnect'; data: { userName: string, townFriendlyName: string, townID: string, townIsPubliclyListed: boolean, sessionToken: string, myPlayerID: string, socket: Socket, players: Player[], emitMovement: (location: UserLocation) => void } }
@@ -79,8 +80,7 @@ function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyApp
         const dx = p.location.x - location.x;
         const dy = p.location.y - location.y;
         const d = Math.sqrt(dx * dx + dy * dy);
-        // TODO: Abstract this out and reuse for chat as well
-        return d < 80;
+        return d < Constants.DEFAULT_BROADCAST_RADIUS;
       }
       return false;
     };

--- a/frontend/src/components/spatialChat/chatInputBox/IChatInputBoxView.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/IChatInputBoxView.tsx
@@ -1,0 +1,6 @@
+interface IChatInputBoxView {
+    value: string;
+    onInputChanged: (inputValue: string) => void;
+}
+
+export default IChatInputBoxView;

--- a/frontend/src/components/spatialChat/chatInputBox/IChatInputBoxView.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/IChatInputBoxView.tsx
@@ -1,6 +1,7 @@
 interface IChatInputBoxView {
     value: string;
     onInputChanged: (inputValue: string) => void;
+    onInputSubmit: () => Promise<void>;
 }
 
 export default IChatInputBoxView;

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBox.test.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBox.test.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable no-await-in-loop,@typescript-eslint/no-loop-func,no-restricted-syntax */
+import React, { ReactElement } from 'react'
+import '@testing-library/jest-dom'
+import { render as rtlRender } from '@testing-library/react'
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import reducer from '../../../redux/reducers';
+import ChatInputBox from './index'
+
+
+// TODO: This needs to be put in a test-utils of some sort. This pattern
+// is used in the containerslist as well.
+// A custom renderer that'll wrap the given element within a redux-provider
+const render = (
+    ui: ReactElement,
+    {
+        initialState = {},
+        ...renderOptions
+    } = {}
+) => {
+    const store = createStore(reducer, initialState);
+    const Wrapper: React.FC = ({ children }) => {
+        return <Provider store={store}>{children}</Provider>
+    }
+    return rtlRender(ui, { wrapper: Wrapper, ...renderOptions })
+}
+
+const mockUseCoveyAppState = jest.fn(() => (Promise.resolve()));
+jest.mock('../../../hooks/useCoveyAppState', () => ({
+    __esModule: true, // this property makes it work
+    default: () => (mockUseCoveyAppState)
+}));
+
+describe('Rendering the conversations list view', () => {
+    it('Test if the chat-input-box is loaded on the screen', () => {
+        const renderedElement = render(
+            <ChatInputBox />,
+        );
+        renderedElement.getByTestId("chat-input-box-wrapper");
+        renderedElement.getByRole('button', { name: /send/ });
+    })
+
+    it('Test if send a message triggers a socket call', () => {
+        const { } = render(
+            <ChatInputBox />,
+        );
+        // TODO:
+    })
+
+});

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
@@ -4,6 +4,7 @@ import { RootState } from '../../../redux/store';
 import { updateCurrentMessageAction } from '../../../redux/actions';
 import ChatInputBoxView from './chatInputBoxView';
 import useCoveyAppState from '../../../hooks/useCoveyAppState';
+import Constants from '../../../constants';
 
 const ChatInputBoxContainer: React.FunctionComponent = () => {
     const chat = useSelector((state: RootState) => state.chat.current_message);
@@ -13,7 +14,7 @@ const ChatInputBoxContainer: React.FunctionComponent = () => {
     const sendChatMessage = () => {
         socket?.emit('sendChatMessage', {
             message: chat,
-            borderRadius: 80,
+            broadcastRadius: Constants.DEFAULT_BROADCAST_RADIUS,
         });
 
         // Set the input to empty after submitting

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
@@ -22,15 +22,17 @@ const ChatInputBoxContainer: React.FunctionComponent = () => {
     }
 
     return (
-        <ChatInputBoxView
-            value={chat}
-            onInputChanged={(inputValue) => {
-                dispatch(updateCurrentMessageAction(inputValue));
-            }}
-            onInputSubmit={async () => {
-                sendChatMessage();
-            }}
-        />
+        <div data-testid="chat-input-box-wrapper">
+            <ChatInputBoxView
+                value={chat}
+                onInputChanged={(inputValue) => {
+                    dispatch(updateCurrentMessageAction(inputValue));
+                }}
+                onInputSubmit={async () => {
+                    sendChatMessage();
+                }}
+            />
+        </div>
     )
 };
 

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
@@ -3,16 +3,28 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../redux/store';
 import { updateCurrentMessageAction } from '../../../redux/actions';
 import ChatInputBoxView from './chatInputBoxView';
+import useCoveyAppState from '../../../hooks/useCoveyAppState';
 
 const ChatInputBoxContainer: React.FunctionComponent = () => {
     const chat = useSelector((state: RootState) => state.chat.current_message);
     const dispatch = useDispatch();
+
+    const { socket } = useCoveyAppState();
+    const sendChatMessage = () => {
+        socket?.emit('sendChatMessage', {
+            message: chat,
+            borderRadius: 80,
+        });
+    }
 
     return (
         <ChatInputBoxView
             value={chat}
             onInputChanged={(inputValue) => {
                 dispatch(updateCurrentMessageAction(inputValue));
+            }}
+            onInputSubmit={async () => {
+                sendChatMessage();
             }}
         />
     )

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
@@ -15,6 +15,9 @@ const ChatInputBoxContainer: React.FunctionComponent = () => {
             message: chat,
             borderRadius: 80,
         });
+
+        // Set the input to empty after submitting
+        dispatch(updateCurrentMessageAction(""));
     }
 
     return (

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxContainer.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../../redux/store';
+import { updateCurrentMessageAction } from '../../../redux/actions';
+import ChatInputBoxView from './chatInputBoxView';
+
+const ChatInputBoxContainer: React.FunctionComponent = () => {
+    const chat = useSelector((state: RootState) => state.chat.current_message);
+    const dispatch = useDispatch();
+
+    return (
+        <ChatInputBoxView
+            value={chat}
+            onInputChanged={(inputValue) => {
+                dispatch(updateCurrentMessageAction(inputValue));
+            }}
+        />
+    )
+};
+
+export default ChatInputBoxContainer;

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
@@ -1,25 +1,23 @@
 import React from 'react';
 import { Input } from '@chakra-ui/react'
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '../../../redux/store';
-import { updateCurrentMessageAction } from '../../../redux/actions';
 
-export const ChatInputBoxView: React.FunctionComponent = () => {
-    const chat = useSelector((state: RootState) => state.chat.current_message);
-    const dispatch = useDispatch();
+interface IChatInputBoxView {
+    value: string;
+    onInputChanged: (inputValue: string) => void;
+}
 
-    return (
-        <div className="chat-box-container">
-            <Input
-                placeholder="Say Something..."
-                size="lg"
-                value={chat}
-                onChange={(e) => {
-                    dispatch(updateCurrentMessageAction(e.target.value));
-                }}
-            />
-        </div>
-    )
-};
+const ChatInputBoxView: React.FunctionComponent<IChatInputBoxView> = (
+    { value, onInputChanged }: IChatInputBoxView) => (
+    <div className="chat-box-container">
+        <Input
+            placeholder="Say Something..."
+            size="lg"
+            value={value}
+            onChange={(e) => {
+                onInputChanged(e.target.value);
+            }}
+        />
+    </div>
+);
 
 export default ChatInputBoxView;

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
@@ -3,7 +3,7 @@ import { Input } from '@chakra-ui/react'
 import IChatInputBoxView from './IChatInputBoxView';
 
 const ChatInputBoxView: React.FunctionComponent<IChatInputBoxView> = (
-    { value, onInputChanged }: IChatInputBoxView) => (
+    { value, onInputChanged, onInputSubmit }: IChatInputBoxView) => (
     <div className="chat-box-container">
         <Input
             placeholder="Say Something..."
@@ -11,6 +11,11 @@ const ChatInputBoxView: React.FunctionComponent<IChatInputBoxView> = (
             value={value}
             onChange={(e) => {
                 onInputChanged(e.target.value);
+            }}
+            onKeyPress={async (e) => {
+                if (e.key === "Enter") {
+                    await onInputSubmit();
+                }
             }}
         />
     </div>

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { Input } from '@chakra-ui/react'
-
-interface IChatInputBoxView {
-    value: string;
-    onInputChanged: (inputValue: string) => void;
-}
+import IChatInputBoxView from './IChatInputBoxView';
 
 const ChatInputBoxView: React.FunctionComponent<IChatInputBoxView> = (
     { value, onInputChanged }: IChatInputBoxView) => (

--- a/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/chatInputBoxView.tsx
@@ -1,23 +1,30 @@
 import React from 'react';
-import { Input } from '@chakra-ui/react'
+import { Button, Input, InputGroup, InputRightElement } from '@chakra-ui/react'
 import IChatInputBoxView from './IChatInputBoxView';
 
 const ChatInputBoxView: React.FunctionComponent<IChatInputBoxView> = (
     { value, onInputChanged, onInputSubmit }: IChatInputBoxView) => (
     <div className="chat-box-container">
-        <Input
-            placeholder="Say Something..."
-            size="lg"
-            value={value}
-            onChange={(e) => {
-                onInputChanged(e.target.value);
-            }}
-            onKeyPress={async (e) => {
-                if (e.key === "Enter") {
-                    await onInputSubmit();
-                }
-            }}
-        />
+        <InputGroup size="md">
+            <Input
+                placeholder="Say Something..."
+                size="lg"
+                value={value}
+                onChange={(e) => {
+                    onInputChanged(e.target.value);
+                }}
+                onKeyPress={async (e) => {
+                    if (e.key === "Enter") {
+                        await onInputSubmit();
+                    }
+                }}
+            />
+            <InputRightElement width="4.5rem">
+                <Button h="1.75rem" size="sm" onClick={onInputSubmit} colorScheme="teal">
+                    send
+                </Button>
+            </InputRightElement>
+        </InputGroup>
     </div>
 );
 

--- a/frontend/src/components/spatialChat/chatInputBox/index.tsx
+++ b/frontend/src/components/spatialChat/chatInputBox/index.tsx
@@ -1,3 +1,3 @@
-import ChatInputBox from './chatInputBoxView';
+import ChatInputBox from './chatInputBoxContainer';
 
 export default ChatInputBox;

--- a/frontend/src/components/spatialChat/spatialChatContainer.tsx
+++ b/frontend/src/components/spatialChat/spatialChatContainer.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
+import { Box } from '@chakra-ui/react';
 import ConversationsList from './conversationsList';
 import ChatInputBox from './chatInputBox';
+
 
 export const SpatialChatContainer: React.FunctionComponent = () =>
 (
     <div>
         Spatial chat container
         <ConversationsList />
-        <ChatInputBox />
+        <Box pos="absolute" bottom="0" width="30%" height="75px">
+            <ChatInputBox />
+        </Box>
+        
     </div>
 );
 

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,0 +1,3 @@
+export default {
+    DEFAULT_BROADCAST_RADIUS: 80,
+}


### PR DESCRIPTION
- Similar to the conversations-list PR, access the redux-store from the chat-input-box.
- I've separated out the old chat-input-box-view into chat-input-box-container and chat-input-box-view. This is due to the fact that later on, we might need to change introduce another component for chat-input-box-view (The rich-text input feature). In which case, the chat-input-box-container can remain the same, and a lot of code-duplication will be saved.