### PR TITLE
[slow-build] Add the eslint plugin

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2830,9 +2830,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-      "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+      "version": "7.2.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
+      "integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7422,9 +7422,9 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ=="
     },
     "eslint-webpack-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.4.0.tgz",
-      "integrity": "sha512-j0lAJj3RnStAFdIH2P0+nsEImiBijwogZhL1go4bI6DE+9OhQuOmJ/xtmxkLtNr1w0cf5SRNkDlmIe8t/pHgww==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.4.1.tgz",
+      "integrity": "sha512-cj8iPWZKuAiVD8MMgTSunyMCAvxQxp5mxoPHZl1UMGkApFXaXJHdCFcCR+oZEJbBNhReNa5SjESIn34uqUbBtg==",
       "requires": {
         "@types/eslint": "^7.2.4",
         "arrify": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-webpack-plugin": "^2.4.1",
     "jest-mock-extended": "^1.0.13",
     "ts-jest": "^26.5.2"
   }


### PR DESCRIPTION
- Addresses the issues with slow builds on the frontend. Turns out this was because eslint was being run entirely on every change (Not phaser as I thought before, since that would've already been cached). 
- Added an eslint-plugin as a dev dependency. It seems to make the hot-reloads much faster. Although the initial loading of the app is slooow. But that's a one-time thing, so not worrying about that now. 
- Have a look at this thread for more details - https://github.com/facebook/create-react-app/issues/9886#issuecomment-747095320

NOTE: This PR is just for info purposes. Closing it as soon as the tests pass!